### PR TITLE
Fix broken w3schools link for HTML DOM

### DIFF
--- a/pages/Injection_Theory.md
+++ b/pages/Injection_Theory.md
@@ -138,7 +138,7 @@ TBD. Recursive descent or LALR parsers.
 
 To really understand what's going on with XSS, you have to consider
 injection into the hierarchical structure of the [HTML
-DOM](http://www.w3schools.com/HTMLDOM/default.asp). Given a place to
+DOM](https://www.w3schools.com/whatis/whatis_htmldom.asp). Given a place to
 insert data into an HTML document (that is, a place where a developer
 has allowed untrusted data to be included in the DOM), there are two
 ways to inject code:


### PR DESCRIPTION
Previous URL was returning 404